### PR TITLE
Integrate libccp

### DIFF
--- a/ebpfccp/Cargo.toml
+++ b/ebpfccp/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.92"
 libbpf-rs = "0.24.6"
+libccp = { git = "https://github.com/claby2/libccp-rust", branch = "fixed" }
 plain = "0.2.3"
 rustyline = "14.0.0"
 

--- a/ebpfccp/build.rs
+++ b/ebpfccp/build.rs
@@ -2,6 +2,7 @@ use std::{env, ffi::OsStr, path::PathBuf};
 use libbpf_cargo::SkeletonBuilder;
 
 const SRC: &str = "src/bpf/datapath.bpf.c";
+const HEADER: &str = "src/bpf/datapath.bpf.h";
 
 fn main() {
     let out = PathBuf::from(
@@ -23,4 +24,5 @@ fn main() {
         .build_and_generate(&out)
         .unwrap();
     println!("cargo:rerun-if-changed={}", SRC);
+    println!("cargo:rerun-if-changed={}", HEADER);
 }

--- a/ebpfccp/src/bpf/datapath.bpf.c
+++ b/ebpfccp/src/bpf/datapath.bpf.c
@@ -107,6 +107,9 @@ static void load_signal(struct sock *sk, const struct rate_sample *rs) {
   if (!sig)
     return;
 
+  u64 sock_addr = (u64)sk;
+  sig->sock_addr = sock_addr;
+
   u64 rin = 0;  // send bandwidth in bytes per second
   u64 rout = 0; // recv bandwidth in bytes per second
   u64 ack_us = rs->rcv_interval_us;

--- a/ebpfccp/src/bpf/datapath.bpf.h
+++ b/ebpfccp/src/bpf/datapath.bpf.h
@@ -121,4 +121,6 @@ static inline unsigned int tcp_packets_in_flight(const struct tcp_sock *tp) {
     __rem;                                                                     \
   })
 
+#define max(x, y) ((x) > (y) ? (x) : (y))
+
 #endif

--- a/ebpfccp/src/bpf/datapath.bpf.h
+++ b/ebpfccp/src/bpf/datapath.bpf.h
@@ -21,11 +21,45 @@ struct signal {
   // newly acked, in-order packets
   u32 packets_acked;
 
+  // out-of-order bytes
+  u32 bytes_misordered;
+
   // out-of-order packets
   u32 packets_misordered;
-  // TODO: Add more congestion primitives
-  //       See `ccp_primitives` in ccp-project/libccp cpp.h
-  //       for more information
+
+  // bytes corresponding to ecn-marked packets
+  u32 ecn_bytes; // TODO: add ECN support
+
+  // ecn-marked packets
+  u32 ecn_packets; // TODO: add ECN support
+
+  // an estimate of the number of packets lost
+  u32 lost_pkts_sample;
+
+  bool was_timeout; // TODO: I think we need to handle this differently, perhaps
+                    // another event buffer
+
+  // a recent sample of the round-trip time
+  u64 rtt_sample_us;
+
+  // sample of the sending rate, bytes / s
+  u64 rate_outgoing;
+  // sample of the receiving rate, bytes / s
+  u64 rate_incoming;
+
+  // the number of actual bytes in flight
+  u32 bytes_in_flight;
+  // the number of actual packets in flight
+  u32 packets_in_flight;
+
+  // the target congestion window to maintain, in bytes
+  u32 snd_cwnd;
+  // target rate to maintain, in bytes/s
+  u64 snd_rate; // TODO: Might be unused?
+
+  // amount of data available to be sent
+  // NOT per-packet - an absolute measurement
+  u32 bytes_pending;
 } _signal = {0};
 
 // New connection message
@@ -63,6 +97,14 @@ static inline void *inet_csk_ca(const struct sock *sk) {
 
 static inline struct tcp_sock *tcp_sk(const struct sock *sk) {
   return (struct tcp_sock *)sk;
+}
+
+static inline unsigned int tcp_left_out(const struct tcp_sock *tp) {
+  return tp->sacked_out + tp->lost_out;
+}
+
+static inline unsigned int tcp_packets_in_flight(const struct tcp_sock *tp) {
+  return tp->packets_out - tcp_left_out(tp) + tp->retrans_out;
 }
 
 #define MTU 1500

--- a/ebpfccp/src/bpf/datapath.bpf.h
+++ b/ebpfccp/src/bpf/datapath.bpf.h
@@ -8,11 +8,13 @@
 char _license[] SEC("license") = "GPL";
 
 struct connection {
-  // in unit of bytes, note that kernel tp->snd_cwnd is in packets - translate by * (1/tp->mss)
+  // in unit of bytes, note that kernel tp->snd_cwnd is in packets - translate
+  // by * (1/tp->mss)
   u32 cwnd;
 } _connection = {0};
 
 struct signal {
+  u64 sock_addr;
   // newly acked, in-order bytes
   u32 bytes_acked;
 

--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -20,11 +20,24 @@ unsafe impl Plain for internal::types::create_conn_event {}
 unsafe impl Plain for internal::types::free_conn_event {}
 
 pub struct Signal(internal::types::signal);
+impl Deref for Signal {
+    type Target = internal::types::signal;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 pub struct Connection(internal::types::connection);
+impl Deref for Connection {
+    type Target = internal::types::connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 pub struct CreateConnEvent(internal::types::create_conn_event);
-
 impl Deref for CreateConnEvent {
     type Target = internal::types::create_conn_event;
 
@@ -34,6 +47,13 @@ impl Deref for CreateConnEvent {
 }
 
 pub struct FreeConnEvent(internal::types::free_conn_event);
+impl Deref for FreeConnEvent {
+    type Target = internal::types::free_conn_event;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Convenience wrapper around the generated skeleton.
 pub struct Skeleton<'a>(internal::DatapathSkel<'a>);
@@ -55,7 +75,7 @@ fn poll(map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<
 
 impl<'a> Skeleton<'a> {
     pub fn load(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
-        let mut skel_builder = internal::DatapathSkelBuilder::default();
+        let skel_builder = internal::DatapathSkelBuilder::default();
 
         //skel_builder.obj_builder.debug(true); // Enable debug mode
 

--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -1,10 +1,19 @@
 use anyhow::Result;
 use libbpf_rs::{
     skel::{OpenSkel, SkelBuilder},
-    MapCore, OpenObject, RingBufferBuilder,
+    MapCore, MapFlags, OpenObject, RingBufferBuilder,
 };
 use plain::Plain;
-use std::{mem::MaybeUninit, ops::Deref, time::Duration};
+use std::{
+    mem::MaybeUninit,
+    ops::Deref,
+    sync::{
+        mpsc::{self, Receiver, Sender},
+        Arc, RwLock,
+    },
+    thread,
+    time::Duration,
+};
 
 // Encapsulating this inside an internal module to avoid leaking everything.
 mod internal {
@@ -22,15 +31,6 @@ unsafe impl Plain for internal::types::free_conn_event {}
 pub struct Signal(internal::types::signal);
 impl Deref for Signal {
     type Target = internal::types::signal;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-pub struct Connection(internal::types::connection);
-impl Deref for Connection {
-    type Target = internal::types::connection;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -55,15 +55,25 @@ impl Deref for FreeConnEvent {
     }
 }
 
+#[derive(Debug)]
+pub enum ConnectionMessage {
+    SetCwnd(u64, u32),
+    SetRateAbs(u64, u32),
+}
+
 /// Convenience wrapper around the generated skeleton.
-pub struct Skeleton<'a>(internal::DatapathSkel<'a>);
+pub struct Skeleton {
+    skel: Arc<RwLock<&'static internal::DatapathSkel<'static>>>,
+    tx: Sender<ConnectionMessage>,
+    rx: Option<Receiver<ConnectionMessage>>,
+}
 
 // Generic poll function that can be used to poll any ring buffer.
 fn poll(map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<()> {
     let mut ring_builder = RingBufferBuilder::new();
     ring_builder.add(map, callback)?;
     let ring = ring_builder.build()?;
-    std::thread::spawn(move || loop {
+    thread::spawn(move || loop {
         // Poll all open ring buffers until timeout is reached or when there are no more events.
         if let Err(e) = ring.poll(Duration::MAX) {
             eprintln!("Error polling ring buffer: {:?}", e);
@@ -73,13 +83,23 @@ fn poll(map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<
     Ok(())
 }
 
-impl<'a> Skeleton<'a> {
-    pub fn load(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+// copied from https://stackoverflow.com/a/42186553
+unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
+    ::core::slice::from_raw_parts((p as *const T) as *const u8, ::core::mem::size_of::<T>())
+}
+
+impl Skeleton {
+    pub fn load() -> Result<Self> {
+        let open_object = MaybeUninit::uninit();
+        let open_object_box = Box::new(open_object);
+        let open_object_static_ref: &'static mut MaybeUninit<OpenObject> =
+            Box::leak(open_object_box);
+
         let skel_builder = internal::DatapathSkelBuilder::default();
 
         //skel_builder.obj_builder.debug(true); // Enable debug mode
 
-        let open_skel = skel_builder.open(open_object)?;
+        let open_skel = skel_builder.open(open_object_static_ref)?;
 
         // We could technically modify the BPF program through open_skel here, I do not see much
         // reason for this for now.
@@ -90,11 +110,26 @@ impl<'a> Skeleton<'a> {
         // At this point, the BPF program is loaded and attached to the kernel.
         // We should be able to see the CCA in `/proc/sys/net/ipv4/tcp_available_congestion_control`.
 
-        Ok(Skeleton(skel))
+        let skel_box = Box::new(skel);
+        let skel_static_ref: &'static internal::DatapathSkel = Box::leak(skel_box);
+
+        let (tx, rx) = mpsc::channel();
+
+        Ok(Skeleton {
+            skel: Arc::new(RwLock::new(skel_static_ref)),
+            tx,
+            rx: Some(rx),
+        })
+    }
+
+    pub fn sender(&self) -> Sender<ConnectionMessage> {
+        self.tx.clone()
     }
 
     pub fn poll_signals(&self, callback: impl Fn(&Signal) + 'static) -> Result<()> {
-        let _ = poll(&self.0.maps.signals, move |data| {
+        let skel = self.skel.clone();
+        let skel = skel.read().unwrap();
+        let _ = poll(&skel.maps.signals, move |data| {
             let mut signal = internal::types::signal::default();
             plain::copy_from_bytes(&mut signal, data).unwrap();
             callback(&Signal(signal));
@@ -107,7 +142,9 @@ impl<'a> Skeleton<'a> {
         &self,
         callback: impl Fn(&CreateConnEvent) + 'static,
     ) -> Result<()> {
-        let _ = poll(&self.0.maps.create_conn_events, move |data| {
+        let skel = self.skel.clone();
+        let skel = skel.read().unwrap();
+        let _ = poll(&skel.maps.create_conn_events, move |data| {
             let mut event = internal::types::create_conn_event::default();
             plain::copy_from_bytes(&mut event, data).unwrap();
             callback(&CreateConnEvent(event));
@@ -117,12 +154,41 @@ impl<'a> Skeleton<'a> {
     }
 
     pub fn poll_free_conn_events(&self, callback: impl Fn(&FreeConnEvent) + 'static) -> Result<()> {
-        let _ = poll(&self.0.maps.free_conn_events, move |data| {
+        let skel = self.skel.clone();
+        let skel = skel.read().unwrap();
+        let _ = poll(&skel.maps.free_conn_events, move |data| {
             let mut event = internal::types::free_conn_event::default();
             plain::copy_from_bytes(&mut event, data).unwrap();
             callback(&FreeConnEvent(event));
             0
         })?;
+        Ok(())
+    }
+
+    pub fn handle_conn_messages(&mut self) -> Result<()> {
+        let rx = self.rx.take().expect("Receiver already taken");
+        let skel = self.skel.clone();
+        thread::spawn(move || loop {
+            match rx.recv() {
+                Ok(ConnectionMessage::SetCwnd(sock_addr, cwnd)) => {
+                    let conn = internal::types::connection { cwnd };
+                    let conn_bytes = unsafe { any_as_u8_slice(&conn) };
+
+                    let skel = skel.read().unwrap();
+                    skel.maps
+                        .connections
+                        .update(&sock_addr.to_ne_bytes(), conn_bytes, MapFlags::ANY)
+                        .unwrap();
+                }
+                Ok(ConnectionMessage::SetRateAbs(_sock_addr, _rate)) => {
+                    todo!("Set rate abs");
+                }
+                Err(e) => {
+                    eprintln!("Error receiving message: {:?}", e);
+                    break;
+                }
+            }
+        });
         Ok(())
     }
 }

--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -4,7 +4,7 @@ use libbpf_rs::{
     MapCore, OpenObject, RingBufferBuilder,
 };
 use plain::Plain;
-use std::{mem::MaybeUninit, time::Duration};
+use std::{mem::MaybeUninit, ops::Deref, time::Duration};
 
 // Encapsulating this inside an internal module to avoid leaking everything.
 mod internal {
@@ -24,6 +24,14 @@ pub struct Signal(internal::types::signal);
 pub struct Connection(internal::types::connection);
 
 pub struct CreateConnEvent(internal::types::create_conn_event);
+
+impl Deref for CreateConnEvent {
+    type Target = internal::types::create_conn_event;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 pub struct FreeConnEvent(internal::types::free_conn_event);
 

--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -1,11 +1,100 @@
+use anyhow::Result;
+use libbpf_rs::{
+    skel::{OpenSkel, SkelBuilder},
+    MapCore, OpenObject, RingBufferBuilder,
+};
 use plain::Plain;
+use std::{mem::MaybeUninit, time::Duration};
 
-include!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/src/bpf/datapath.skel.rs"
-));
+// Encapsulating this inside an internal module to avoid leaking everything.
+mod internal {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bpf/datapath.skel.rs"
+    ));
+}
 
-unsafe impl Plain for types::signal {}
-unsafe impl Plain for types::connection {}
-unsafe impl Plain for types::create_conn_event {}
-unsafe impl Plain for types::free_conn_event {}
+unsafe impl Plain for internal::types::signal {}
+unsafe impl Plain for internal::types::connection {}
+unsafe impl Plain for internal::types::create_conn_event {}
+unsafe impl Plain for internal::types::free_conn_event {}
+
+pub struct Signal(internal::types::signal);
+
+pub struct Connection(internal::types::connection);
+
+pub struct CreateConnEvent(internal::types::create_conn_event);
+
+pub struct FreeConnEvent(internal::types::free_conn_event);
+
+/// Convenience wrapper around the generated skeleton.
+pub struct Skeleton<'a>(internal::DatapathSkel<'a>);
+
+// Generic poll function that can be used to poll any ring buffer.
+fn poll(map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<()> {
+    let mut ring_builder = RingBufferBuilder::new();
+    ring_builder.add(map, callback)?;
+    let ring = ring_builder.build()?;
+    std::thread::spawn(move || loop {
+        // Poll all open ring buffers until timeout is reached or when there are no more events.
+        if let Err(e) = ring.poll(Duration::MAX) {
+            eprintln!("Error polling ring buffer: {:?}", e);
+            std::process::exit(1);
+        }
+    });
+    Ok(())
+}
+
+impl<'a> Skeleton<'a> {
+    pub fn load(open_object: &'a mut MaybeUninit<OpenObject>) -> Result<Self> {
+        let mut skel_builder = internal::DatapathSkelBuilder::default();
+
+        //skel_builder.obj_builder.debug(true); // Enable debug mode
+
+        let open_skel = skel_builder.open(open_object)?;
+
+        // We could technically modify the BPF program through open_skel here, I do not see much
+        // reason for this for now.
+
+        let mut skel = open_skel.load()?;
+        let _link = skel.maps.ebpfccp.attach_struct_ops()?;
+
+        // At this point, the BPF program is loaded and attached to the kernel.
+        // We should be able to see the CCA in `/proc/sys/net/ipv4/tcp_available_congestion_control`.
+
+        Ok(Skeleton(skel))
+    }
+
+    pub fn poll_signals(&self, callback: impl Fn(&Signal) + 'static) -> Result<()> {
+        let _ = poll(&self.0.maps.signals, move |data| {
+            let mut signal = internal::types::signal::default();
+            plain::copy_from_bytes(&mut signal, data).unwrap();
+            callback(&Signal(signal));
+            0
+        })?;
+        Ok(())
+    }
+
+    pub fn poll_create_conn_events(
+        &self,
+        callback: impl Fn(&CreateConnEvent) + 'static,
+    ) -> Result<()> {
+        let _ = poll(&self.0.maps.create_conn_events, move |data| {
+            let mut event = internal::types::create_conn_event::default();
+            plain::copy_from_bytes(&mut event, data).unwrap();
+            callback(&CreateConnEvent(event));
+            0
+        })?;
+        Ok(())
+    }
+
+    pub fn poll_free_conn_events(&self, callback: impl Fn(&FreeConnEvent) + 'static) -> Result<()> {
+        let _ = poll(&self.0.maps.free_conn_events, move |data| {
+            let mut event = internal::types::free_conn_event::default();
+            plain::copy_from_bytes(&mut event, data).unwrap();
+            callback(&FreeConnEvent(event));
+            0
+        })?;
+        Ok(())
+    }
+}

--- a/ebpfccp/src/main.rs
+++ b/ebpfccp/src/main.rs
@@ -7,10 +7,10 @@ use datapath::Skeleton;
 use rustyline::{error::ReadlineError, DefaultEditor};
 
 fn main() -> Result<()> {
-    let mut skel = Skeleton::load()?;
     let mut manager = Manager::new()?;
 
-    manager.start(&mut skel)?;
+    let mut skel = Skeleton::load()?;
+    manager.start(&skel)?;
     skel.handle_conn_messages()?;
 
     let mut rl = DefaultEditor::new()?;
@@ -21,6 +21,9 @@ fn main() -> Result<()> {
                 let tokens: Vec<&str> = line.split_whitespace().collect();
                 match tokens.as_slice() {
                     ["exit"] => break,
+                    ["list", "connections"] => {
+                        manager.list_connections();
+                    }
                     _ => {
                         eprintln!("Invalid command");
                     }

--- a/ebpfccp/src/main.rs
+++ b/ebpfccp/src/main.rs
@@ -5,15 +5,13 @@ use crate::manager::Manager;
 use anyhow::Result;
 use datapath::Skeleton;
 use rustyline::{error::ReadlineError, DefaultEditor};
-use std::mem::MaybeUninit;
 
 fn main() -> Result<()> {
-    let mut open_object = MaybeUninit::uninit();
-    let skel = Skeleton::load(&mut open_object)?;
-
+    let mut skel = Skeleton::load()?;
     let mut manager = Manager::new()?;
 
-    manager.start(&skel)?;
+    manager.start(&mut skel)?;
+    skel.handle_conn_messages()?;
 
     let mut rl = DefaultEditor::new()?;
     loop {

--- a/ebpfccp/src/main.rs
+++ b/ebpfccp/src/main.rs
@@ -3,6 +3,7 @@ mod manager;
 
 use crate::manager::Manager;
 use anyhow::Result;
+use datapath::Skeleton;
 use libbpf_rs::{
     skel::{OpenSkel, SkelBuilder},
     MapCore, MapFlags,
@@ -11,26 +12,12 @@ use rustyline::{error::ReadlineError, DefaultEditor};
 use std::mem::MaybeUninit;
 
 fn main() -> Result<()> {
-    let mut skel_builder = datapath::DatapathSkelBuilder::default();
-
-    skel_builder.obj_builder.debug(true); // Enable debug mode
-
     let mut open_object = MaybeUninit::uninit();
-    let open_skel = skel_builder.open(&mut open_object)?;
+    let mut skel = Skeleton::load(&mut open_object)?;
 
-    // We could technically modify the BPF program through open_skel here, I do not see much
-    // reason for this for now.
+    let mut manager = Manager::new()?;
 
-    let mut skel = open_skel.load()?;
-    let _link = skel.maps.ebpfccp.attach_struct_ops()?;
-
-    // At this point, the BPF program is loaded and attached to the kernel.
-    // We should be able to see the CCA in `/proc/sys/net/ipv4/tcp_available_congestion_control`.
-
-    let manager = Manager::default();
-    manager.poll_signals(&skel)?;
-    manager.poll_create_conn_events(&skel)?;
-    manager.poll_free_conn_events(&skel)?;
+    manager.start(&skel)?;
 
     let mut rl = DefaultEditor::new()?;
     loop {
@@ -40,37 +27,6 @@ fn main() -> Result<()> {
                 let tokens: Vec<&str> = line.split_whitespace().collect();
                 match tokens.as_slice() {
                     ["exit"] => break,
-                    ["list", "connections"] => {
-                        for key in skel.maps.connections.keys() {
-                            let conn_bytes = skel.maps.connections.lookup(&key, MapFlags::ANY)?;
-                            let key: u64 = *plain::from_bytes(&key)
-                                .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
-                            if let Some(conn_bytes) = conn_bytes {
-                                let conn =
-                                    plain::from_bytes::<datapath::types::connection>(&conn_bytes)
-                                        .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))?;
-                                println!(
-                                    "{} (sid: {:?}): {:?}",
-                                    key,
-                                    manager.get_socket_id(key),
-                                    conn
-                                );
-                            }
-                        }
-                    },
-                    ["set", "cwnd", socket_id, cwnd_bytes] => {
-                        if *socket_id == "all" {
-                            let cwnd_bytes: u32 = cwnd_bytes.parse()?;
-                            for key in manager.get_all_socket_ids() {
-                                manager.update_cwnd_for_socket(&skel, key, cwnd_bytes);
-                            }
-                        } else {
-                            let socket_id: u32 = socket_id.parse()?;
-                            let cwnd_bytes: u32 = cwnd_bytes.parse()?;
-                            manager.update_cwnd_for_socket(&skel, socket_id, cwnd_bytes);
-                        }
-                        
-                    },
                     _ => {
                         eprintln!("Invalid command");
                     }

--- a/ebpfccp/src/main.rs
+++ b/ebpfccp/src/main.rs
@@ -4,16 +4,12 @@ mod manager;
 use crate::manager::Manager;
 use anyhow::Result;
 use datapath::Skeleton;
-use libbpf_rs::{
-    skel::{OpenSkel, SkelBuilder},
-    MapCore, MapFlags,
-};
 use rustyline::{error::ReadlineError, DefaultEditor};
 use std::mem::MaybeUninit;
 
 fn main() -> Result<()> {
     let mut open_object = MaybeUninit::uninit();
-    let mut skel = Skeleton::load(&mut open_object)?;
+    let skel = Skeleton::load(&mut open_object)?;
 
     let mut manager = Manager::new()?;
 

--- a/ebpfccp/src/manager.rs
+++ b/ebpfccp/src/manager.rs
@@ -159,8 +159,17 @@ impl Manager {
                 let primitives = libccp::Primitives::default()
                     .with_bytes_acked(signal.bytes_acked)
                     .with_packets_acked(signal.packets_acked)
-                    .with_packets_misordered(signal.packets_misordered);
-                // TODO: Add more fields to primitives
+                    .with_bytes_misordered(signal.bytes_misordered)
+                    .with_packets_misordered(signal.packets_misordered)
+                    .with_lost_pkts_sample(signal.lost_pkts_sample)
+                    .with_rtt_sample_us(signal.rtt_sample_us)
+                    .with_rate_outgoing(signal.rate_outgoing)
+                    .with_rate_incoming(signal.rate_incoming)
+                    .with_bytes_in_flight(signal.bytes_in_flight)
+                    .with_packets_in_flight(signal.packets_in_flight)
+                    .with_snd_cwnd(signal.snd_cwnd)
+                    .with_bytes_pending(signal.bytes_pending);
+                // TODO: Add more primitives (just a few more I believe)
 
                 conn.load_primitives(primitives);
             }

--- a/ebpfccp/src/manager.rs
+++ b/ebpfccp/src/manager.rs
@@ -1,135 +1,78 @@
 use anyhow::Result;
-use libbpf_rs::{MapCore, RingBufferBuilder, MapFlags};
+use libbpf_rs::{MapCore, MapFlags, RingBufferBuilder};
+use libccp::{self, CongestionOps, DatapathOps};
 use std::{
     collections::HashMap,
+    os::unix::net::UnixDatagram,
     sync::{Arc, Mutex},
     time::Duration,
 };
 
-use crate::datapath;
+use crate::datapath::Skeleton;
 
-pub type SocketId = u32;
-pub type SocketAddr = u64;
+const FROM_CCP_SOCKET: &str = "/tmp/ccp/0/out";
+const TO_CCP_SOCKET: &str = "/tmp/ccp/0/in";
 
-// Bidirectional map between socket ID and socket address.
-#[derive(Debug, Default)]
-struct SocketMap {
-    id_to_addr: HashMap<SocketId, SocketAddr>,
-    addr_to_id: HashMap<SocketAddr, SocketId>,
+/// Socket interface to communicate with CCP congestion control algorithm
+#[derive(Debug)]
+pub struct SocketOperator {
+    socket: UnixDatagram,
 }
 
-impl SocketMap {
-    fn insert(&mut self, id: SocketId, addr: SocketAddr) {
-        self.id_to_addr.insert(id, addr);
-        self.addr_to_id.insert(addr, id);
-    }
-
-    fn remove_addr(&mut self, addr: SocketAddr) {
-        if let Some(id) = self.addr_to_id.remove(&addr) {
-            self.id_to_addr.remove(&id);
-        }
-    }
-
-    fn get_id(&self, addr: SocketAddr) -> Option<SocketId> {
-        self.addr_to_id.get(&addr).copied()
-    }
-
-    fn get_addr(&self, id: SocketId) -> Option<SocketAddr> {
-        self.id_to_addr.get(&id).copied()
-    }
-
-    fn unused_id(&self) -> SocketId {
-        let mut id = 0;
-        while self.id_to_addr.contains_key(&id) {
-            id += 1;
-        }
-        id
-    }
-
-    fn get_all_ids(&self) -> Vec<SocketId> {
-        self.id_to_addr.keys().copied().collect()
+impl SocketOperator {
+    pub fn new() -> Result<Self> {
+        let socket = UnixDatagram::bind(TO_CCP_SOCKET)?;
+        Ok(Self { socket })
     }
 }
 
-// copied from https://stackoverflow.com/a/42186553
-unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
-    ::core::slice::from_raw_parts(
-        (p as *const T) as *const u8,
-        ::core::mem::size_of::<T>(),
-    )
+impl DatapathOps for SocketOperator {
+    fn send_msg(&mut self, msg: &[u8]) {
+        todo!("Send message to CCP congestion control algorithm");
+    }
 }
 
-#[derive(Debug, Default)]
+/// Manage connection-level state and operations
+#[derive(Debug)]
+pub struct Connection {}
+
+impl CongestionOps for Connection {
+    fn set_cwnd(&mut self, cwnd: u32) {
+        todo!("Set congestion window");
+    }
+
+    fn set_rate_abs(&mut self, rate: u32) {
+        todo!("Set rate");
+    }
+}
+
 pub struct Manager {
-    socket_map: Arc<Mutex<SocketMap>>,
+    datapath: libccp::Datapath,
 }
 
 impl Manager {
-    pub fn get_socket_id(&self, addr: SocketAddr) -> Option<SocketId> {
-        self.socket_map.lock().unwrap().get_id(addr)
+    pub fn new() -> Result<Self> {
+        let so = SocketOperator::new()?;
+        let datapath = libccp::DatapathBuilder::default()
+            .with_ops(so)
+            .with_id(0)
+            .init()?;
+        Ok(Self { datapath })
     }
 
-    // Generic poll function that can be used to poll any ring buffer.
-    fn poll(&self, map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<()> {
-        let mut ring_builder = RingBufferBuilder::new();
-        ring_builder.add(map, callback)?;
-        let ring = ring_builder.build()?;
-        std::thread::spawn(move || loop {
-            // Poll all open ring buffers until timeout is reached or when there are no more events.
-            if let Err(e) = ring.poll(Duration::MAX) {
-                eprintln!("Error polling ring buffer: {:?}", e);
-                std::process::exit(1);
-            }
-        });
+    pub fn start(&mut self, skeleton: &Skeleton) -> Result<()> {
+        skeleton.poll_signals(move |signal| {
+            println!("Received signal");
+        })?;
+
+        skeleton.poll_create_conn_events(move |event| {
+            println!("Received create connection event");
+        })?;
+
+        skeleton.poll_free_conn_events(move |event| {
+            println!("Received free connection event");
+        })?;
+
         Ok(())
-    }
-
-    pub fn poll_signals(&self, skel: &datapath::DatapathSkel) -> Result<()> {
-        self.poll(&skel.maps.signals, |data| {
-            let mut event = datapath::types::signal::default();
-            plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
-            // dbg!(event);
-            0
-        })
-    }
-
-    pub fn poll_create_conn_events(&self, skel: &datapath::DatapathSkel) -> Result<()> {
-        let socket_map = self.socket_map.clone();
-        self.poll(&skel.maps.create_conn_events, move |data| {
-            let mut event = datapath::types::create_conn_event::default();
-            plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
-            println!("Create conn event: {:?}", event);
-            let mut socket_map = socket_map.lock().unwrap();
-            let id = socket_map.unused_id();
-            socket_map.insert(id, event.sock_addr);
-            0
-        })
-    }
-
-    pub fn poll_free_conn_events(&self, skel: &datapath::DatapathSkel) -> Result<()> {
-        let socket_map = self.socket_map.clone();
-        self.poll(&skel.maps.free_conn_events, move |data| {
-            let mut event = datapath::types::free_conn_event::default();
-            plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
-            println!("Free conn event: {:?}", event);
-            let mut socket_map = socket_map.lock().unwrap();
-            socket_map.remove_addr(event.sock_addr);
-            0
-        })
-    }
-
-    pub fn update_cwnd_for_socket(&self, skel: &datapath::DatapathSkel, id: SocketId, cwnd: u32) {
-        let socket_addr = self.socket_map.lock().unwrap().get_addr(id);
-        if let Some(addr) = socket_addr {
-            let conn = datapath::types::connection { 
-                cwnd: cwnd,
-            };
-            let conn_bytes = unsafe { any_as_u8_slice(&conn) };
-            let _ = skel.maps.connections.update(&addr.to_ne_bytes(), conn_bytes, MapFlags::ANY);
-        }
-    }
-
-    pub fn get_all_socket_ids(&self) -> Vec<SocketId> {
-        self.socket_map.lock().unwrap().get_all_ids()
     }
 }


### PR DESCRIPTION
This PR integrates ebpfccp with [libccp-rust](https://github.com/akshayknarayan/libccp-rust), Rust bindings for libccp. With this PR, ebpfccp can communicate with a CCA implementation that uses portus.

The codebase has been reorganized to facilitate this integration. Specifically:

- `datapath.rs` now serves as a convenient layer between the eBPF skeleton and the rest of the Rust codebase. It provides `Skeleton`, which abstracts away various eBPF operations, such as polling ring buffers and updating BPF maps.
- `manager.rs` now implements the `DatapathOps` and `CongestionOps` traits of `libccp-rust`. It provides a `Manager` that manages the interaction with `libccp`. Communication with ccp is handled via Unix domain sockets.

On the eBPF side, I’ve added support for more primitives. A few more primitives still need to be implemented (like ECN). We should also consider rethinking how we handle primitives and signals to make it easier to emulate calling `ccp_invoke` in various hooks. This is something we can discuss.

To test the PR, follow these steps:
1. Start a CCA implementation that uses [portus](https://github.com/ccp-project/portus/tree/master/src) (version `0.8` is required, as `0.7` seems to have broken Unix socket support). You’ll probably need to run as root. I have tested with [ccp-project/generic-cong-avoid](https://github.com/ccp-project/generic-cong-avoid/tree/master), you just need to change the portus dependency from version `0.7` to `0.8`.
2. Start up ebpfcca (again, as root).
3. Set TCP CCA and run `iperf`.

I haven’t been able to test whether the CCA signals calls to `set_cwnd` or `set_rate_abs` yet. I’m unsure if this is because there’s no congestion (unlikely) or if there are still some things we need to implement. However, there seems to be consistent communication between portus/CCA and ebpfcca (the sockets remain open, and no errors are reported on either side).

TODO:
- Support ECN.
- Handle timeouts (`was_timeout` is one of the primitives).
- Implement a way to set `rate_abs` (currently, we only have a way to set `cwnd`).
- Get `set_rate_abs` working.
- Conduct more testing and benchmarking.
- (Possibly) refactor how primitives and signals work.