### PR TITLE
fix: call ccp_invoke

### DIFF
--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -32,7 +32,7 @@ pub type FreeConnEvent = internal::types::free_conn_event;
 
 #[derive(Debug)]
 pub enum ConnectionMessage {
-    SetCwnd(u64, u32), // SocketAddr, packets in send_cwnd
+    SetCwnd(u64, u32),    // SocketAddr, packets in send_cwnd
     SetRateAbs(u64, u32), // SocketAddr, bytes/second for sk_pacing_rate
 }
 
@@ -148,34 +148,38 @@ impl Skeleton {
             match rx.recv() {
                 Ok(ConnectionMessage::SetCwnd(sock_addr, cwnd)) => {
                     let socket_addr = sock_addr.to_ne_bytes();
-                    let conn_opt = skel.maps.connections
+                    let conn_opt = skel
+                        .maps
+                        .connections
                         .lookup(&socket_addr, MapFlags::ANY)
                         .unwrap();
                     if let Some(conn_bytes) = conn_opt {
-                            let mut conn = internal::types::connection::default();
-                            plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
-                            conn.cwnd = cwnd;
-                            let conn_bytes = unsafe { any_as_u8_slice(&conn) };
-                            skel.maps
-                                .connections
-                                .update(&socket_addr, conn_bytes, MapFlags::ANY)
-                                .unwrap();
+                        let mut conn = internal::types::connection::default();
+                        plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
+                        conn.cwnd = cwnd;
+                        let conn_bytes = unsafe { any_as_u8_slice(&conn) };
+                        skel.maps
+                            .connections
+                            .update(&socket_addr, conn_bytes, MapFlags::ANY)
+                            .unwrap();
                     }
                 }
                 Ok(ConnectionMessage::SetRateAbs(sock_addr, rate)) => {
                     let socket_addr = sock_addr.to_ne_bytes();
-                    let conn_opt = skel.maps.connections
+                    let conn_opt = skel
+                        .maps
+                        .connections
                         .lookup(&socket_addr, MapFlags::ANY)
                         .unwrap();
                     if let Some(conn_bytes) = conn_opt {
-                            let mut conn = internal::types::connection::default();
-                            plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
-                            conn.pacing_rate = rate;
-                            let conn_bytes = unsafe { any_as_u8_slice(&conn) };
-                            skel.maps
-                                .connections
-                                .update(&socket_addr, conn_bytes, MapFlags::ANY)
-                                .unwrap();
+                        let mut conn = internal::types::connection::default();
+                        plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
+                        conn.pacing_rate = rate;
+                        let conn_bytes = unsafe { any_as_u8_slice(&conn) };
+                        skel.maps
+                            .connections
+                            .update(&socket_addr, conn_bytes, MapFlags::ANY)
+                            .unwrap();
                     }
                 }
                 Err(e) => {

--- a/ebpfccp/src/datapath.rs
+++ b/ebpfccp/src/datapath.rs
@@ -64,6 +64,24 @@ fn poll(map: &dyn MapCore, callback: impl Fn(&[u8]) -> i32 + 'static) -> Result<
     Ok(())
 }
 
+fn update_connection(
+    skel: &internal::DatapathSkel,
+    sock_addr: u64,
+    update_fn: impl Fn(&mut internal::types::connection),
+) -> Result<()> {
+    let socket_addr = sock_addr.to_ne_bytes();
+    if let Some(conn_bytes) = skel.maps.connections.lookup(&socket_addr, MapFlags::ANY)? {
+        let mut conn = internal::types::connection::default();
+        plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
+        update_fn(&mut conn);
+        let conn_bytes = unsafe { any_as_u8_slice(&conn) };
+        skel.maps
+            .connections
+            .update(&socket_addr, conn_bytes, MapFlags::ANY)?;
+    }
+    Ok(())
+}
+
 // copied from https://stackoverflow.com/a/42186553
 unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     ::core::slice::from_raw_parts((p as *const T) as *const u8, ::core::mem::size_of::<T>())
@@ -147,39 +165,19 @@ impl Skeleton {
         thread::spawn(move || loop {
             match rx.recv() {
                 Ok(ConnectionMessage::SetCwnd(sock_addr, cwnd)) => {
-                    let socket_addr = sock_addr.to_ne_bytes();
-                    let conn_opt = skel
-                        .maps
-                        .connections
-                        .lookup(&socket_addr, MapFlags::ANY)
-                        .unwrap();
-                    if let Some(conn_bytes) = conn_opt {
-                        let mut conn = internal::types::connection::default();
-                        plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
+                    println!("Setting cwnd for {:?} to {}", sock_addr, cwnd);
+                    if let Err(e) = update_connection(skel, sock_addr, |conn| {
                         conn.cwnd = cwnd;
-                        let conn_bytes = unsafe { any_as_u8_slice(&conn) };
-                        skel.maps
-                            .connections
-                            .update(&socket_addr, conn_bytes, MapFlags::ANY)
-                            .unwrap();
+                    }) {
+                        eprintln!("Error updating cwnd: {:?}", e);
                     }
                 }
                 Ok(ConnectionMessage::SetRateAbs(sock_addr, rate)) => {
-                    let socket_addr = sock_addr.to_ne_bytes();
-                    let conn_opt = skel
-                        .maps
-                        .connections
-                        .lookup(&socket_addr, MapFlags::ANY)
-                        .unwrap();
-                    if let Some(conn_bytes) = conn_opt {
-                        let mut conn = internal::types::connection::default();
-                        plain::copy_from_bytes(&mut conn, &conn_bytes[..]).unwrap();
+                    println!("Setting pacing rate for {:?} to {}", sock_addr, rate);
+                    if let Err(e) = update_connection(skel, sock_addr, |conn| {
                         conn.pacing_rate = rate;
-                        let conn_bytes = unsafe { any_as_u8_slice(&conn) };
-                        skel.maps
-                            .connections
-                            .update(&socket_addr, conn_bytes, MapFlags::ANY)
-                            .unwrap();
+                    }) {
+                        eprintln!("Error updating pacing rate: {:?}", e);
                     }
                 }
                 Err(e) => {

--- a/ebpfccp/src/manager.rs
+++ b/ebpfccp/src/manager.rs
@@ -144,7 +144,9 @@ impl Manager {
             let mut buf = [0; 1024];
             loop {
                 let size = socket_operator.recv(&mut buf).unwrap();
-                dp.recv_msg(&mut buf[..size]).unwrap();
+                if let Err(e) = dp.recv_msg(&mut buf[..size]) {
+                    eprintln!("Failed to receive message: {:?}", e);
+                }
             }
         });
     }
@@ -172,6 +174,9 @@ impl Manager {
                 // TODO: Add more primitives (just a few more I believe)
 
                 conn.load_primitives(primitives);
+                if let Err(e) = conn.invoke() {
+                    eprintln!("Failed to invoke connection: {:?}", e);
+                }
             }
         })
     }


### PR DESCRIPTION
This PR calls libccp's [Connection::invoke](https://docs.rs/libccp/latest/libccp/struct.Connection.html#method.invoke) to ensure measurements get sent to the CCP. Our program now successfully receives `set_cwnd` events!

(also deduplicated some of the connection message handling code).